### PR TITLE
correcting typo in example python command line fmt

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ script summarize-enron.py (an empty file is provided) that can be run from the
 [Unix] command line in the format:
 
 ```
-> python summarize-python.py enron-event-history-all.csv
+> python summarize-enron.py enron-event-history-all.csv
 ```
 The Enron event history (.csv, adapted from the widely-used publicly available
 data set) is included in this repo. The columns contain:


### PR DESCRIPTION
Hey, just randomly remembered this typo and my intention to open PR to fix, so I figured I'd do it now before I forgot again. :)
